### PR TITLE
Correct requires-python key name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.3.6"
 authors = [ { name = "Nathan Whitehead", email = "nwhitehe@gmail.com" } ]
 description = "Python bindings for using SoundFonts (sf2/sf3/sfo formats), generating audio samples, and playing MIDI songs"
 readme = "README.md"
-python_requires = ">=3.7"
+requires-python = ">=3.7"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
In order to give wider compatibility when installing tinysoundfont, use the standard `requires-python` key rather than `python_requires`. In particular this will ensure compatibility with `scikit-build-core` versions `0.2.0` and greater.